### PR TITLE
Implement roadmap and user career features

### DIFF
--- a/Controllers/UserSelectionController.cs
+++ b/Controllers/UserSelectionController.cs
@@ -1,0 +1,35 @@
+using CareerGuidancePlatform.Dtos;
+using CareerGuidancePlatform.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace CareerGuidancePlatform.Controllers
+{
+    [ApiController]
+    [Authorize]
+    public class UserSelectionController : ControllerBase
+    {
+        private readonly IUserService _userService;
+        private readonly IRoadmapService _roadmapService;
+
+        public UserSelectionController(IUserService userService, IRoadmapService roadmapService)
+        {
+            _userService = userService;
+            _roadmapService = roadmapService;
+        }
+
+        [HttpPost("api/user/selection")]
+        public async Task<IActionResult> SaveSelection([FromBody] UserSelectionDto dto)
+        {
+            var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdClaim == null) return Unauthorized();
+
+            if (!int.TryParse(userIdClaim, out var userId)) return Unauthorized();
+
+            await _userService.SaveCareerChoiceAsync(userId, dto.Career, dto.Niche);
+            var roadmap = await _roadmapService.GetRoadmapAsync(dto.Career, dto.Niche);
+            return Ok(roadmap);
+        }
+    }
+}

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -14,5 +14,18 @@
             public DbSet<Message> Messages { get; set; }
             public DbSet<MeetingRequest> MeetingRequests { get; set; }
             public DbSet<GroupSession> GroupSessions { get; set; }
+
+            public DbSet<RoadmapStep> RoadmapSteps { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.Entity<RoadmapStep>()
+                    .Property(r => r.ResourceLinks)
+                    .HasConversion(
+                        v => System.Text.Json.JsonSerializer.Serialize(v, (System.Text.Json.JsonSerializerOptions)null!),
+                        v => System.Text.Json.JsonSerializer.Deserialize<List<string>>(v) ?? new List<string>());
+            }
         }
     }

--- a/Dtos/RoadmapStepDto.cs
+++ b/Dtos/RoadmapStepDto.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace CareerGuidancePlatform.Dtos
+{
+    public class RoadmapStepDto
+    {
+        public int Order { get; set; }
+        public string Phase { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Detail { get; set; } = string.Empty;
+        public string EstimatedTime { get; set; } = string.Empty;
+        public List<string> ResourceLinks { get; set; } = new();
+        public bool IsOptional { get; set; }
+    }
+}

--- a/Dtos/UserSelectionDto.cs
+++ b/Dtos/UserSelectionDto.cs
@@ -1,0 +1,8 @@
+namespace CareerGuidancePlatform.Dtos
+{
+    public class UserSelectionDto
+    {
+        public string Career { get; set; } = string.Empty;
+        public string Niche { get; set; } = string.Empty;
+    }
+}

--- a/Migrations/20250607120000_AddRoadmapSteps.cs
+++ b/Migrations/20250607120000_AddRoadmapSteps.cs
@@ -1,0 +1,70 @@
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CareerGuidancePlatform.Migrations
+{
+    public class AddRoadmapSteps : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Career",
+                table: "Users",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Niche",
+                table: "Users",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "RoadmapSteps",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Career = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Niche = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    Phase = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Title = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Detail = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    EstimatedTime = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ResourceLinks = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    IsOptional = table.Column<bool>(type: "tinyint(1)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RoadmapSteps", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RoadmapSteps");
+
+            migrationBuilder.DropColumn(
+                name: "Career",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "Niche",
+                table: "Users");
+        }
+    }
+}

--- a/Models/RoadmapStep.cs
+++ b/Models/RoadmapStep.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace CareerGuidancePlatform.Models
+{
+    public class RoadmapStep
+    {
+        public int Id { get; set; }
+        public string Career { get; set; } = string.Empty;
+        public string Niche { get; set; } = string.Empty;
+        public int Order { get; set; }
+        public string Phase { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Detail { get; set; } = string.Empty;
+        public string EstimatedTime { get; set; } = string.Empty;
+        public List<string> ResourceLinks { get; set; } = new();
+        public bool IsOptional { get; set; }
+    }
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -19,5 +19,9 @@ namespace CareerGuidancePlatform.Models
         public string PasswordHash { get; set; } = string.Empty;
 
         public string Role { get; set; } = "User";
+
+        public string Career { get; set; } = string.Empty;
+
+        public string Niche { get; set; } = string.Empty;
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 using CareerGuidancePlatform.Data;
+using CareerGuidancePlatform.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
@@ -43,6 +44,8 @@ builder.Services.AddControllers();        // ✅ Cho Web API
 builder.Services.AddControllersWithViews();
 builder.Services.AddSession();
 builder.Services.AddAuthorization();
+builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<IRoadmapService, RoadmapService>();
 
 var app = builder.Build();
 

--- a/Services/IRoadmapService.cs
+++ b/Services/IRoadmapService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CareerGuidancePlatform.Dtos;
+
+namespace CareerGuidancePlatform.Services
+{
+    public interface IRoadmapService
+    {
+        Task<List<RoadmapStepDto>> GetRoadmapAsync(string career, string niche);
+    }
+}

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace CareerGuidancePlatform.Services
+{
+    public interface IUserService
+    {
+        Task SaveCareerChoiceAsync(int userId, string career, string niche);
+    }
+}

--- a/Services/RoadmapService.cs
+++ b/Services/RoadmapService.cs
@@ -1,0 +1,35 @@
+using CareerGuidancePlatform.Data;
+using CareerGuidancePlatform.Dtos;
+using CareerGuidancePlatform.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CareerGuidancePlatform.Services
+{
+    public class RoadmapService : IRoadmapService
+    {
+        private readonly AppDbContext _context;
+
+        public RoadmapService(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<RoadmapStepDto>> GetRoadmapAsync(string career, string niche)
+        {
+            return await _context.RoadmapSteps
+                .Where(r => r.Career == career && r.Niche == niche)
+                .OrderBy(r => r.Order)
+                .Select(r => new RoadmapStepDto
+                {
+                    Order = r.Order,
+                    Phase = r.Phase,
+                    Title = r.Title,
+                    Detail = r.Detail,
+                    EstimatedTime = r.EstimatedTime,
+                    ResourceLinks = r.ResourceLinks,
+                    IsOptional = r.IsOptional
+                })
+                .ToListAsync();
+        }
+    }
+}

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -1,0 +1,25 @@
+using CareerGuidancePlatform.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace CareerGuidancePlatform.Services
+{
+    public class UserService : IUserService
+    {
+        private readonly AppDbContext _context;
+
+        public UserService(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task SaveCareerChoiceAsync(int userId, string career, string niche)
+        {
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.UserId == userId);
+            if (user == null) return;
+
+            user.Career = career;
+            user.Niche = niche;
+            await _context.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RoadmapStep` model and configure JSON resource link storage
- extend `User` with `Career` and `Niche`
- create DTOs for user selection and roadmap step
- implement `IRoadmapService`/`RoadmapService` and `IUserService`/`UserService`
- add `UserSelectionController` with `/api/user/selection` endpoint
- register new services in DI
- provide initial migration for new schema changes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abfdd10588330a6bed1802f877ba0